### PR TITLE
Remove symlinks from single slot to slot1, not needed with gateway-id…

### DIFF
--- a/conf/rak_rak7289v2/files/etc/rc.local
+++ b/conf/rak_rak7289v2/files/etc/rc.local
@@ -1,3 +1,0 @@
-# Make gateway-id show first slot Gateway ID
-ln -s /tmp/concentratord_slot1_command /tmp/concentratord_command
-ln -s /tmp/concentratord_slot1_event /tmp/concentratord_event

--- a/conf/rak_rak7391/files/etc/rc.local
+++ b/conf/rak_rak7391/files/etc/rc.local
@@ -1,9 +1,5 @@
 PG_VERSION=$(postgres -V | awk '{print $NF}')
 
-# Make gateway-id show first slot Gateway ID
-ln -s /tmp/concentratord_slot1_command /tmp/concentratord_command
-ln -s /tmp/concentratord_slot1_event /tmp/concentratord_event
-
 # Fixup after upgrade
 chown -R postgres:postgres /srv/postgresql/${PG_VERSION}
 if [ -d "/srv/postgresql/${PG_VERSION}/data" ]; then


### PR DESCRIPTION
Delete symlinks to slot1 pipes no longer required with https://github.com/chirpstack/chirpstack-openwrt-feed/pull/7
Only merge this PR if the other one is also merged.