### PR TITLE
Fix broken python3 dependency for Dockerfile-devel

### DIFF
--- a/Dockerfile-devel
+++ b/Dockerfile-devel
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     'git' \
     'libncurses5-dev' \
     'libssl-dev' \
-    'python3-distutils' \
+    'python3' \
     'rsync' \
     'unzip' \
     'zlib1g-dev' \

--- a/Dockerfile-devel
+++ b/Dockerfile-devel
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     'libncurses5-dev' \
     'libssl-dev' \
     'python3' \
+    'python3-setuptools' \
     'rsync' \
     'unzip' \
     'zlib1g-dev' \


### PR DESCRIPTION
While following the README and setting up the development environment, the Docker container failed when installing `python3-distutils`:
> E: Package 'python3-distutils' has no installation candidate

This PR updates the Dockerfile to install `python3` (which is required by the build process) instead, which resolves the issue.